### PR TITLE
Potential fix for code scanning alert no. 16: Uncontrolled command line

### DIFF
--- a/DefaultModules/ModuleDev/Services/ModuleBuildService.cs
+++ b/DefaultModules/ModuleDev/Services/ModuleBuildService.cs
@@ -33,7 +33,6 @@ internal sealed partial class ModuleBuildService(ModuleWorkspaceService workspac
     private static readonly TimeSpan BuildTimeout = TimeSpan.FromSeconds(120);
     private static readonly HashSet<string> AllowedConfigurations =
         new(StringComparer.OrdinalIgnoreCase) { "Debug", "Release" };
-    private static readonly Regex ModuleIdRegex = new("^[A-Za-z0-9_-]+$", RegexOptions.CultureInvariant);
 
     /// <summary>
     /// Build a module project. Returns structured diagnostics.
@@ -133,8 +132,9 @@ internal sealed partial class ModuleBuildService(ModuleWorkspaceService workspac
     private static string EnsureSafeModuleId(string moduleId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(moduleId, nameof(moduleId));
-        if (!ModuleIdRegex.IsMatch(moduleId))
-            throw new ArgumentException("Module ID contains invalid characters.", nameof(moduleId));
+        if (!ModuleIdRegex().IsMatch(moduleId))
+            throw new ArgumentException(
+                $"Invalid module ID '{moduleId}'. Must match ^[a-z][a-z0-9_]{{0,39}}$.", nameof(moduleId));
         return moduleId;
     }
 
@@ -164,6 +164,9 @@ internal sealed partial class ModuleBuildService(ModuleWorkspaceService workspac
 
         return diagnostics;
     }
+
+    [GeneratedRegex(@"^[a-z][a-z0-9_]{0,39}$")]
+    private static partial Regex ModuleIdRegex();
 
     [GeneratedRegex(@"(?<file>[^(]+)\((?<line>\d+),(?<col>\d+)\):\s+(?<severity>error|warning)\s+(?<code>\w+):\s+(?<msg>.+)")]
     private static partial Regex MsBuildDiagnosticRegex();

--- a/DefaultModules/ModuleDev/Services/ModuleBuildService.cs
+++ b/DefaultModules/ModuleDev/Services/ModuleBuildService.cs
@@ -33,6 +33,7 @@ internal sealed partial class ModuleBuildService(ModuleWorkspaceService workspac
     private static readonly TimeSpan BuildTimeout = TimeSpan.FromSeconds(120);
     private static readonly HashSet<string> AllowedConfigurations =
         new(StringComparer.OrdinalIgnoreCase) { "Debug", "Release" };
+    private static readonly Regex ModuleIdRegex = new("^[A-Za-z0-9_-]+$", RegexOptions.CultureInvariant);
 
     /// <summary>
     /// Build a module project. Returns structured diagnostics.
@@ -45,8 +46,9 @@ internal sealed partial class ModuleBuildService(ModuleWorkspaceService workspac
                 $"Invalid build configuration '{configuration}'. Allowed: {string.Join(", ", AllowedConfigurations)}.",
                 nameof(configuration));
 
+        var safeModuleId = EnsureSafeModuleId(moduleId);
         var moduleDir = PathGuard.EnsureContainedIn(
-            workspace.ResolveModuleDir(moduleId), ModuleService.ResolveExternalModulesDir());
+            workspace.ResolveModuleDir(safeModuleId), ModuleService.ResolveExternalModulesDir());
 
         if (!Directory.Exists(moduleDir))
             throw new DirectoryNotFoundException($"Module directory not found: {moduleDir}");
@@ -126,6 +128,14 @@ internal sealed partial class ModuleBuildService(ModuleWorkspaceService workspac
         }
 
         return new BuildResult(success, errors, warnings, outputDll, rawOutput);
+    }
+
+    private static string EnsureSafeModuleId(string moduleId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(moduleId);
+        if (!ModuleIdRegex.IsMatch(moduleId))
+            throw new ArgumentException("Module ID contains invalid characters.", nameof(moduleId));
+        return moduleId;
     }
 
     // ── MSBuild diagnostic parsing ────────────────────────────────

--- a/DefaultModules/ModuleDev/Services/ModuleBuildService.cs
+++ b/DefaultModules/ModuleDev/Services/ModuleBuildService.cs
@@ -132,7 +132,7 @@ internal sealed partial class ModuleBuildService(ModuleWorkspaceService workspac
 
     private static string EnsureSafeModuleId(string moduleId)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(moduleId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(moduleId, nameof(moduleId));
         if (!ModuleIdRegex.IsMatch(moduleId))
             throw new ArgumentException("Module ID contains invalid characters.", nameof(moduleId));
         return moduleId;


### PR DESCRIPTION
Potential fix for [https://github.com/mkn8rn/SharpClaw/security/code-scanning/16](https://github.com/mkn8rn/SharpClaw/security/code-scanning/16)

Use a **strict module-id allowlist normalization at the process-launch boundary**, then derive `moduleDir` from that sanitized value before setting `WorkingDirectory`.

Best fix without changing behavior:
- In `DefaultModules/ModuleDev/Services/ModuleBuildService.cs`, add a local sanitizer method that only accepts expected module id characters (e.g. `A-Z a-z 0-9 _ -`) and rejects empty/whitespace.
- In `BuildAsync`, sanitize `moduleId` first and use the sanitized value for `ResolveModuleDir(...)`.
- Keep existing `EnsureContainedIn(...)` and all current checks (defense in depth).
- This gives CodeQL a clearer sanitization boundary close to the sink and preserves existing behavior for valid module IDs.

No new packages are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
