### PR TITLE
Potential fix for code scanning alert no. 16: Uncontrolled command line

### DIFF
--- a/DefaultModules/ModuleDev/Services/ModuleBuildService.cs
+++ b/DefaultModules/ModuleDev/Services/ModuleBuildService.cs
@@ -69,7 +69,7 @@ internal sealed partial class ModuleBuildService(ModuleWorkspaceService workspac
             FileName = "dotnet",
             ArgumentList = { "build", csprojPath, "-c", configuration, "-nologo",
                 "-consoleloggerparameters:NoSummary" },
-            WorkingDirectory = moduleDir,
+            WorkingDirectory = ModuleService.ResolveExternalModulesDir(),
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,


### PR DESCRIPTION
Potential fix for [https://github.com/mkn8rn/SharpClaw/security/code-scanning/16](https://github.com/mkn8rn/SharpClaw/security/code-scanning/16)

General fix: ensure process-launch parameters (`WorkingDirectory`, executable path, arguments) are built only from trusted, canonicalized values, and avoid passing values that are directly dataflow-linked to request input into process execution properties.

Best fix here (minimal behavior change): in `DefaultModules/ModuleDev/Services/ModuleBuildService.cs`, set `WorkingDirectory` to the trusted external-modules root (`ModuleService.ResolveExternalModulesDir()`), while still passing the validated full `.csproj` path as an explicit build target argument. `dotnet build <full-path-to-csproj>` does not require the project directory as working directory, so behavior remains effectively the same while breaking the taint path into the sink.

Edits needed:
- File: `DefaultModules/ModuleDev/Services/ModuleBuildService.cs`
- Region: inside `BuildAsync`, in the `ProcessStartInfo` initializer near current line 72.
- No new imports, methods, or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
