### PR TITLE
Potential fix for code scanning alert no. 30: Uncontrolled data used in path expression

### DIFF
--- a/SharpClaw.Application.Core/Services/ModuleService.cs
+++ b/SharpClaw.Application.Core/Services/ModuleService.cs
@@ -281,9 +281,10 @@ public sealed class ModuleService(
     public async Task<ModuleStateResponse> LoadExternalAsync(
         string moduleDir, IServiceProvider hostServices, CancellationToken ct = default)
     {
-        // Validate that moduleDir is strictly inside the external-modules root.
+        // Validate that moduleDir resolves strictly inside the external-modules root.
         var externalRoot = ResolveExternalModulesDir();
-        var canonicalModuleDir = PathGuard.EnsureContainedIn(moduleDir, externalRoot);
+        var combinedModuleDir = Path.Combine(externalRoot, moduleDir);
+        var canonicalModuleDir = PathGuard.EnsureContainedIn(combinedModuleDir, externalRoot);
 
         var manifestPath = PathGuard.EnsureContainedIn(
             Path.Combine(canonicalModuleDir, "module.json"), canonicalModuleDir);

--- a/SharpClaw.Utils/Security/PathGuard.cs
+++ b/SharpClaw.Utils/Security/PathGuard.cs
@@ -16,12 +16,23 @@ public static class PathGuard
     /// </exception>
     public static string EnsureContainedIn(string combined, string parentDir)
     {
-        var canonical = Path.GetFullPath(combined);
-        var canonicalParent = Path.GetFullPath(parentDir) + Path.DirectorySeparatorChar;
+        ArgumentException.ThrowIfNullOrWhiteSpace(combined);
+        ArgumentException.ThrowIfNullOrWhiteSpace(parentDir);
 
-        if (!canonical.StartsWith(canonicalParent, StringComparison.OrdinalIgnoreCase))
+        if (combined.Contains('\0') || parentDir.Contains('\0'))
+            throw new InvalidOperationException("Path contains null bytes.");
+
+        var canonical = Path.GetFullPath(combined);
+        var canonicalParent = Path.GetFullPath(parentDir)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var canonicalParentWithSep = canonicalParent + Path.DirectorySeparatorChar;
+
+        if (!canonical.Equals(canonicalParent, StringComparison.OrdinalIgnoreCase) &&
+            !canonical.StartsWith(canonicalParentWithSep, StringComparison.OrdinalIgnoreCase))
+        {
             throw new InvalidOperationException(
                 $"Path '{combined}' escapes the allowed directory '{parentDir}'.");
+        }
 
         return canonical;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/mkn8rn/SharpClaw/security/code-scanning/30](https://github.com/mkn8rn/SharpClaw/security/code-scanning/30)

Use an explicit “combine with trusted base, then validate containment” flow at the call site, instead of accepting a precombined path string from upstream. This reduces trust in caller-provided path composition and gives CodeQL a clearer safe pattern.

Best fix with minimal functionality change:

- In `ModuleService.LoadExternalAsync` (in `SharpClaw.Application.Core/Services/ModuleService.cs`), treat `moduleDir` as a module identifier/path segment, not as an already-safe absolute path.
- Build `canonicalModuleDir` by combining the trusted base (`externalRoot`) with `moduleDir`, then pass that to `PathGuard.EnsureContainedIn`.
- Keep existing manifest path validation.
- In `PathGuard.EnsureContainedIn` (in `SharpClaw.Utils/Security/PathGuard.cs`), harden input validation (`null/whitespace`, null byte checks) and normalize parent consistently before comparison. This improves security posture and helps static analyzers recognize a robust sanitization boundary.

No external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
