### PR TITLE
Potential fix for code scanning alert no. 22: Uncontrolled data used in path expression

### DIFF
--- a/DefaultModules/ModuleDev/Services/ModuleWorkspaceService.cs
+++ b/DefaultModules/ModuleDev/Services/ModuleWorkspaceService.cs
@@ -26,7 +26,11 @@ internal sealed class ModuleWorkspaceService
     public string ResolveModuleDir(string moduleId)
     {
         ValidateModuleId(moduleId);
-        return Path.Combine(_externalModulesDir, moduleId);
+
+        var moduleDir = Path.GetFullPath(Path.Combine(_externalModulesDir, moduleId));
+        PathGuard.EnsureContainedIn(moduleDir, _externalModulesDir);
+
+        return moduleDir;
     }
 
     /// <summary>
@@ -38,7 +42,7 @@ internal sealed class ModuleWorkspaceService
         ValidateModuleId(moduleId);
         ValidateRelativePath(relativePath);
 
-        var moduleDir = Path.GetFullPath(Path.Combine(_externalModulesDir, moduleId));
+        var moduleDir = ResolveModuleDir(moduleId);
         var fullPath = Path.GetFullPath(Path.Combine(moduleDir, relativePath));
 
         if (!fullPath.StartsWith(moduleDir + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
Potential fix for [https://github.com/mkn8rn/SharpClaw/security/code-scanning/22](https://github.com/mkn8rn/SharpClaw/security/code-scanning/22)

General fix: canonicalize and constrain user-derived path components to a trusted base directory before any file operation, and reject inputs that resolve outside that base.

Best targeted fix here: update `ResolveModuleDir` so it returns a fully resolved path and explicitly enforces containment within `_externalModulesDir` using `PathGuard.EnsureContainedIn`. This makes `moduleId` handling robust and explicit for analyzers and runtime safety, while preserving behavior for valid inputs. `ResolveFilePath` can then rely on a safe module root from `ResolveModuleDir` instead of recomputing from raw combine.  
Change region: `DefaultModules/ModuleDev/Services/ModuleWorkspaceService.cs`:
- In `ResolveModuleDir`, replace `Path.Combine(...)` return with canonicalized `Path.GetFullPath(...)`, then `PathGuard.EnsureContainedIn(...)`, then return.
- In `ResolveFilePath`, replace direct `moduleDir` construction with call to `ResolveModuleDir(moduleId)`.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
