### PR TITLE
feat: add in-process module secret reader

### DIFF
--- a/DefaultModules/AgentOrchestration/SharpClaw.Modules.AgentOrchestration.csproj
+++ b/DefaultModules/AgentOrchestration/SharpClaw.Modules.AgentOrchestration.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DefaultModules/EditorCommon/SharpClaw.Modules.EditorCommon.csproj
+++ b/DefaultModules/EditorCommon/SharpClaw.Modules.EditorCommon.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DefaultModules/Metrics/SharpClaw.Modules.Metrics.csproj
+++ b/DefaultModules/Metrics/SharpClaw.Modules.Metrics.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DefaultModules/ModuleDev/SharpClaw.Modules.ModuleDev.csproj
+++ b/DefaultModules/ModuleDev/SharpClaw.Modules.ModuleDev.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
     <ProjectReference Include="..\..\SharpClaw.Utils\SharpClaw.Utils.csproj" />
   </ItemGroup>
 

--- a/DefaultModules/Providers/Anthropic/SharpClaw.Modules.Providers.Anthropic.csproj
+++ b/DefaultModules/Providers/Anthropic/SharpClaw.Modules.Providers.Anthropic.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\..\..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
     <ProjectReference Include="..\..\..\SharpClaw.Providers.Common\SharpClaw.Providers.Common.csproj" />
   </ItemGroup>
 

--- a/DefaultModules/Providers/Google/SharpClaw.Modules.Providers.Google.csproj
+++ b/DefaultModules/Providers/Google/SharpClaw.Modules.Providers.Google.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\..\..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
     <ProjectReference Include="..\..\..\SharpClaw.Providers.Common\SharpClaw.Providers.Common.csproj" />
   </ItemGroup>
 

--- a/DefaultModules/Providers/LlamaSharp/SharpClaw.Modules.Providers.LlamaSharp.csproj
+++ b/DefaultModules/Providers/LlamaSharp/SharpClaw.Modules.Providers.LlamaSharp.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\..\..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
     <ProjectReference Include="..\..\..\SharpClaw.Utils\SharpClaw.Utils.csproj" />
     <ProjectReference Include="..\..\..\SharpClaw.Providers.Common\SharpClaw.Providers.Common.csproj" />
     <ProjectReference Include="..\..\..\SharpClaw.Providers.LocalCommon\SharpClaw.Providers.LocalCommon.csproj" />

--- a/DefaultModules/Providers/Ollama/SharpClaw.Modules.Providers.Ollama.csproj
+++ b/DefaultModules/Providers/Ollama/SharpClaw.Modules.Providers.Ollama.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\..\..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
     <ProjectReference Include="..\..\..\SharpClaw.Providers.Common\SharpClaw.Providers.Common.csproj" />
   </ItemGroup>
 

--- a/DefaultModules/Providers/OpenAICompatible/SharpClaw.Modules.Providers.OpenAICompatible.csproj
+++ b/DefaultModules/Providers/OpenAICompatible/SharpClaw.Modules.Providers.OpenAICompatible.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\..\..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
     <ProjectReference Include="..\..\..\SharpClaw.Providers.Common\SharpClaw.Providers.Common.csproj" />
   </ItemGroup>
 

--- a/DefaultModules/TestHarness/SharpClaw.Modules.TestHarness.csproj
+++ b/DefaultModules/TestHarness/SharpClaw.Modules.TestHarness.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DefaultModules/VS2026Editor/SharpClaw.Modules.VS2026Editor.csproj
+++ b/DefaultModules/VS2026Editor/SharpClaw.Modules.VS2026Editor.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\EditorCommon\SharpClaw.Modules.EditorCommon.csproj" />
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DefaultModules/VSCodeEditor/SharpClaw.Modules.VSCodeEditor.csproj
+++ b/DefaultModules/VSCodeEditor/SharpClaw.Modules.VSCodeEditor.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\EditorCommon\SharpClaw.Modules.EditorCommon.csproj" />
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SharpClaw.Application.API/Program.cs
+++ b/SharpClaw.Application.API/Program.cs
@@ -346,6 +346,7 @@ try
     builder.Services.AddScoped<IAgentJobReader, HostAgentJobReader>();
     builder.Services.AddSingleton<IAgentJobCostTracker, HostAgentJobCostTracker>();
     builder.Services.AddSingleton<IModelInfoProvider, HostModelInfoProvider>();
+    builder.Services.AddSingleton<IInProcessModuleSecretReader, HostInProcessModuleSecretReader>();
     builder.Services.AddScoped<IModelRegistrar, HostModelRegistrar>();
     builder.Services.AddSingleton<ChatCache>();
     builder.Services.AddScoped<IContainerProvisioner, HostContainerProvisioner>();

--- a/SharpClaw.Application.API/SharpClaw.Application.API.csproj
+++ b/SharpClaw.Application.API/SharpClaw.Application.API.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SharpClaw.Application.Core\SharpClaw.Application.Core.csproj" />
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
     <ProjectReference Include="..\SharpClaw.Providers.Common\SharpClaw.Providers.Common.csproj" />
     <ProjectReference Include="..\SharpClaw.Application.Infrastructure\SharpClaw.Application.Infrastructure.csproj" />
     <ProjectReference Include="..\SharpClaw.Utils\SharpClaw.Utils.csproj" />

--- a/SharpClaw.Application.Core/Modules/ExternalModuleHost.cs
+++ b/SharpClaw.Application.Core/Modules/ExternalModuleHost.cs
@@ -100,6 +100,7 @@ public sealed class ExternalModuleHost : IModuleRuntimeHost
         // model registry, and module-owned EF persistence.
         ForwardSingleton<IModuleDbContextFactory>(hostServices, services);
         ForwardSingleton<IModelInfoProvider>(hostServices, services);
+        ForwardSingleton<IInProcessModuleSecretReader>(hostServices, services);
         ForwardSingleton<IAgentJobCostTracker>(hostServices, services);
         ForwardSingleton<EncryptionOptions>(hostServices, services);
         ForwardSingleton<ICliIdResolver>(hostServices, services);

--- a/SharpClaw.Application.Core/Modules/HostModuleContractAdapters.cs
+++ b/SharpClaw.Application.Core/Modules/HostModuleContractAdapters.cs
@@ -86,8 +86,7 @@ public sealed class HostAgentJobReader(AgentJobService jobs) : IAgentJobReader
 }
 
 public sealed class HostModelInfoProvider(
-    IServiceScopeFactory scopeFactory,
-    Contracts.Persistence.EncryptionOptions encryptionOptions) : IModelInfoProvider
+    IServiceScopeFactory scopeFactory) : IModelInfoProvider
 {
     public async Task<ModelProviderInfo?> GetModelProviderInfoAsync(Guid modelId, CancellationToken ct = default)
     {
@@ -101,12 +100,51 @@ public sealed class HostModelInfoProvider(
         if (model is null)
             return null;
 
-        var apiKey = string.IsNullOrEmpty(model.Provider.EncryptedApiKey)
-            ? string.Empty
-            : ApiKeyEncryptor.DecryptOrPassthrough(model.Provider.EncryptedApiKey, encryptionOptions.Key);
-
-        return new ModelProviderInfo(model.Name, model.Provider.ProviderKey, apiKey);
+        return new ModelProviderInfo(model.Name, model.Provider.ProviderKey);
     }
+}
+
+public sealed class HostInProcessModuleSecretReader(
+    IServiceScopeFactory scopeFactory,
+    Contracts.Persistence.EncryptionOptions encryptionOptions) : IInProcessModuleSecretReader
+{
+    public async Task<string?> GetProviderApiKeyAsync(
+        string providerKey, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(providerKey))
+            throw new ArgumentException("Provider key must not be blank.", nameof(providerKey));
+
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<SharpClawDbContext>();
+
+        var encryptedApiKey = await db.Providers
+            .Where(provider => provider.ProviderKey == providerKey)
+            .Select(provider => provider.EncryptedApiKey)
+            .FirstOrDefaultAsync(ct);
+
+        return DecryptOrNull(encryptedApiKey);
+    }
+
+    public async Task<string?> GetModelProviderApiKeyAsync(
+        Guid modelId, CancellationToken ct = default)
+    {
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<SharpClawDbContext>();
+
+        var encryptedApiKey = await db.Models
+            .Where(model => model.Id == modelId)
+            .Select(model => model.Provider.EncryptedApiKey)
+            .FirstOrDefaultAsync(ct);
+
+        return DecryptOrNull(encryptedApiKey);
+    }
+
+    private string? DecryptOrNull(string? encryptedApiKey) =>
+        string.IsNullOrEmpty(encryptedApiKey)
+            ? null
+            : ApiKeyEncryptor.DecryptOrPassthrough(
+                encryptedApiKey,
+                encryptionOptions.Key);
 }
 
 /// <summary>

--- a/SharpClaw.Application.Core/SharpClaw.Application.Core.csproj
+++ b/SharpClaw.Application.Core/SharpClaw.Application.Core.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
     <ProjectReference Include="..\SharpClaw.Utils\SharpClaw.Utils.csproj" />
     <ProjectReference Include="..\SharpClaw.Modules.Hosting\SharpClaw.Modules.Hosting.csproj" />
     <ProjectReference Include="..\SharpClaw.Application.Infrastructure\SharpClaw.Application.Infrastructure.csproj" />

--- a/SharpClaw.Application.Infrastructure.Tasks/SharpClaw.Application.Infrastructure.Tasks.csproj
+++ b/SharpClaw.Application.Infrastructure.Tasks/SharpClaw.Application.Infrastructure.Tasks.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/SharpClaw.Application.Infrastructure/SharpClaw.Application.Infrastructure.csproj
+++ b/SharpClaw.Application.Infrastructure/SharpClaw.Application.Infrastructure.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
     <ProjectReference Include="..\SharpClaw.Providers.Common\SharpClaw.Providers.Common.csproj" />
     <ProjectReference Include="..\SharpClaw.Utils\SharpClaw.Utils.csproj" />
   </ItemGroup>

--- a/SharpClaw.Contracts/Modules/IInProcessModuleSecretReader.cs
+++ b/SharpClaw.Contracts/Modules/IInProcessModuleSecretReader.cs
@@ -1,0 +1,15 @@
+namespace SharpClaw.Contracts.Modules;
+
+/// <summary>
+/// Provides protected secret reads to in-process modules running inside the
+/// SharpClaw host process. This interface is intentionally not exposed through
+/// the foreign-module protocol.
+/// </summary>
+public interface IInProcessModuleSecretReader
+{
+    Task<string?> GetProviderApiKeyAsync(
+        string providerKey, CancellationToken ct = default);
+
+    Task<string?> GetModelProviderApiKeyAsync(
+        Guid modelId, CancellationToken ct = default);
+}

--- a/SharpClaw.Contracts/Modules/IModelInfoProvider.cs
+++ b/SharpClaw.Contracts/Modules/IModelInfoProvider.cs
@@ -4,7 +4,7 @@ namespace SharpClaw.Contracts.Modules;
 /// Provides read-only model and provider information needed to start
 /// module-owned inference jobs.
 /// Implemented host-side; injected into modules that must resolve a
-/// model's API key and provider key without touching Core directly.
+/// model and provider metadata without touching Core directly.
 /// </summary>
 public interface IModelInfoProvider
 {
@@ -35,8 +35,6 @@ public interface IModelInfoProvider
 /// </summary>
 /// <param name="ModelName">The model name / identifier string to pass to the API.</param>
 /// <param name="ProviderKey">The provider key that owns the model.</param>
-/// <param name="DecryptedApiKey">Decrypted API key, or empty for local models.</param>
 public sealed record ModelProviderInfo(
     string ModelName,
-    string ProviderKey,
-    string DecryptedApiKey);
+    string ProviderKey);

--- a/SharpClaw.Contracts/SharpClaw.Contracts.csproj
+++ b/SharpClaw.Contracts/SharpClaw.Contracts.csproj
@@ -8,7 +8,10 @@
     <!-- NuGet package metadata -->
     <IsPackable>true</IsPackable>
     <PackageId>SharpClaw.Contracts</PackageId>
-    <Version>0.3.3</Version>
+    <Version>0.3.17</Version>
+    <AssemblyVersion>0.3.17.0</AssemblyVersion>
+    <FileVersion>0.3.17.0</FileVersion>
+    <InformationalVersion>0.3.17</InformationalVersion>
     <Authors>mkn8rn</Authors>
     <Description>Contracts and interfaces for building SharpClaw external modules. Provides ISharpClawModule, DTOs, and shared abstractions.</Description>
     <PackageTags>sharpclaw;modules;contracts;sdk</PackageTags>

--- a/SharpClaw.Gateway/SharpClaw.Gateway.csproj
+++ b/SharpClaw.Gateway/SharpClaw.Gateway.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
     <ProjectReference Include="..\SharpClaw.Gateway.Abstractions\SharpClaw.Gateway.Abstractions.csproj" />
     <ProjectReference Include="..\SharpClaw.Modules.Hosting\SharpClaw.Modules.Hosting.csproj" />
     <ProjectReference Include="..\SharpClaw.Utils\SharpClaw.Utils.csproj" />

--- a/SharpClaw.Providers.Common/SharpClaw.Providers.Common.csproj
+++ b/SharpClaw.Providers.Common/SharpClaw.Providers.Common.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/SharpClaw.Providers.LocalCommon/SharpClaw.Providers.LocalCommon.csproj
+++ b/SharpClaw.Providers.LocalCommon/SharpClaw.Providers.LocalCommon.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
     <ProjectReference Include="..\SharpClaw.Utils\SharpClaw.Utils.csproj" />
   </ItemGroup>
 

--- a/SharpClaw.Tests.ExternalModule/SharpClaw.Tests.ExternalModule.csproj
+++ b/SharpClaw.Tests.ExternalModule/SharpClaw.Tests.ExternalModule.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/SharpClaw.Tests/Modules/InProcessModuleSecretReaderTests.cs
+++ b/SharpClaw.Tests/Modules/InProcessModuleSecretReaderTests.cs
@@ -1,0 +1,215 @@
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SharpClaw.Application.Core.Modules;
+using SharpClaw.Application.Core.Modules.Foreign;
+using SharpClaw.Contracts.Entities.Core;
+using SharpClaw.Contracts.Modules;
+using SharpClaw.Contracts.Persistence;
+using SharpClaw.Infrastructure.Persistence;
+using SharpClaw.Modules.TestHarness;
+using SharpClaw.Utils.Security;
+
+namespace SharpClaw.Tests.Modules;
+
+[TestFixture]
+public sealed class InProcessModuleSecretReaderTests
+{
+    [Test]
+    public async Task GetProviderApiKeyAsync_ReturnsDecryptedProviderKey()
+    {
+        await using var services = CreateServices(out var encryptionOptions);
+        var provider = await SeedProviderAsync(
+            services,
+            encryptionOptions,
+            providerKey: "elevenlabs",
+            apiKey: "xi-secret");
+
+        var reader = services.GetRequiredService<IInProcessModuleSecretReader>();
+
+        var apiKey = await reader.GetProviderApiKeyAsync(provider.ProviderKey);
+
+        apiKey.Should().Be("xi-secret");
+    }
+
+    [Test]
+    public async Task GetModelProviderApiKeyAsync_ReturnsDecryptedProviderKey()
+    {
+        await using var services = CreateServices(out var encryptionOptions);
+        var provider = await SeedProviderAsync(
+            services,
+            encryptionOptions,
+            providerKey: "elevenlabs",
+            apiKey: "xi-model-secret");
+        var model = await SeedModelAsync(services, provider);
+
+        var reader = services.GetRequiredService<IInProcessModuleSecretReader>();
+
+        var apiKey = await reader.GetModelProviderApiKeyAsync(model.Id);
+
+        apiKey.Should().Be("xi-model-secret");
+    }
+
+    [Test]
+    public async Task SecretReader_ReturnsNullForMissingOrUnsetSecrets()
+    {
+        await using var services = CreateServices(out var encryptionOptions);
+        var provider = await SeedProviderAsync(
+            services,
+            encryptionOptions,
+            providerKey: "unset",
+            apiKey: null);
+        var model = await SeedModelAsync(services, provider);
+        var reader = services.GetRequiredService<IInProcessModuleSecretReader>();
+
+        (await reader.GetProviderApiKeyAsync("missing")).Should().BeNull();
+        (await reader.GetProviderApiKeyAsync(provider.ProviderKey)).Should().BeNull();
+        (await reader.GetModelProviderApiKeyAsync(Guid.NewGuid())).Should().BeNull();
+        (await reader.GetModelProviderApiKeyAsync(model.Id)).Should().BeNull();
+    }
+
+    [Test]
+    public async Task GetProviderApiKeyAsync_RejectsBlankProviderKey()
+    {
+        await using var services = CreateServices(out _);
+        var reader = services.GetRequiredService<IInProcessModuleSecretReader>();
+
+        var act = async () => await reader.GetProviderApiKeyAsync(" ");
+
+        await act.Should()
+            .ThrowAsync<ArgumentException>()
+            .WithParameterName("providerKey");
+    }
+
+    [Test]
+    public async Task InProcessModuleScope_CanResolveSecretReader()
+    {
+        await using var services = CreateServices(out _);
+        var moduleDir = Path.GetDirectoryName(typeof(TestHarnessModule).Assembly.Location)!;
+        var manifest = new ModuleManifest(
+            TestHarnessConstants.ModuleId,
+            "Test Harness",
+            "1.0.0",
+            TestHarnessConstants.ToolPrefix,
+            Path.GetFileName(typeof(TestHarnessModule).Assembly.Location),
+            "0.0.0");
+
+        await using var host = ExternalModuleHost.Load(
+            moduleDir,
+            manifest,
+            services,
+            services.GetRequiredService<ILoggerFactory>());
+        using var scope = host.CreateScope();
+
+        scope.ServiceProvider
+            .GetRequiredService<IInProcessModuleSecretReader>()
+            .Should()
+            .BeSameAs(services.GetRequiredService<IInProcessModuleSecretReader>());
+    }
+
+    [Test]
+    public void ModelInfoProviderContract_RemainsNonSecret()
+    {
+        var infoProperties = typeof(ModelProviderInfo)
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Select(property => property.Name)
+            .ToArray();
+
+        infoProperties.Should().BeEquivalentTo("ModelName", "ProviderKey");
+        typeof(IModelInfoProvider)
+            .GetMethods()
+            .Select(method => method.Name)
+            .Should()
+            .NotContain(name => name.Contains("Secret", StringComparison.OrdinalIgnoreCase)
+                || name.Contains("ApiKey", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Test]
+    public void ForeignModuleProtocol_DoesNotExposeSecretReadRoute()
+    {
+        var protocolConstants = typeof(ForeignModuleProtocol)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(string))
+            .Select(field => (string)field.GetValue(null)!)
+            .ToArray();
+
+        protocolConstants.Should().NotContain(value =>
+            value.Contains("secret", StringComparison.OrdinalIgnoreCase)
+            || value.Contains("apikey", StringComparison.OrdinalIgnoreCase)
+            || value.Contains("api-key", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Test]
+    public void ContractsAssemblyIdentity_MatchesPublishedSecretReaderPackageIdentity()
+    {
+        var assemblyName = typeof(IInProcessModuleSecretReader).Assembly.GetName();
+
+        assemblyName.Name.Should().Be("SharpClaw.Contracts");
+        assemblyName.Version.Should().Be(new Version(0, 3, 17, 0));
+        assemblyName.GetPublicKeyToken().Should().BeEmpty();
+    }
+
+    private static ServiceProvider CreateServices(out EncryptionOptions encryptionOptions)
+    {
+        encryptionOptions = new EncryptionOptions
+        {
+            Key = ApiKeyEncryptor.GenerateKey(),
+            EncryptProviderKeys = true,
+        };
+
+        var databaseName = "InProcessSecretReader_" + Guid.NewGuid().ToString("N");
+        var databaseRoot = new InMemoryDatabaseRoot();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(encryptionOptions);
+        services.AddDbContext<SharpClawDbContext>(options =>
+            options.UseInMemoryDatabase(databaseName, databaseRoot));
+        services.AddSingleton<IInProcessModuleSecretReader, HostInProcessModuleSecretReader>();
+
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task<ProviderDB> SeedProviderAsync(
+        IServiceProvider services,
+        EncryptionOptions encryptionOptions,
+        string providerKey,
+        string? apiKey)
+    {
+        await using var scope = services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<SharpClawDbContext>();
+        var provider = new ProviderDB
+        {
+            Id = Guid.NewGuid(),
+            Name = providerKey,
+            ProviderKey = providerKey,
+            EncryptedApiKey = apiKey is null
+                ? null
+                : ApiKeyEncryptor.Encrypt(apiKey, encryptionOptions.Key),
+        };
+        db.Providers.Add(provider);
+        await db.SaveChangesAsync();
+        return provider;
+    }
+
+    private static async Task<ModelDB> SeedModelAsync(
+        IServiceProvider services,
+        ProviderDB provider)
+    {
+        await using var scope = services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<SharpClawDbContext>();
+        var attachedProvider = await db.Providers.FirstAsync(
+            item => item.Id == provider.Id);
+        var model = new ModelDB
+        {
+            Id = Guid.NewGuid(),
+            Name = "elevenlabs-stt",
+            ProviderId = attachedProvider.Id,
+            Provider = attachedProvider,
+        };
+        db.Models.Add(model);
+        await db.SaveChangesAsync();
+        return model;
+    }
+}

--- a/SharpClaw.Uno/SharpClaw.Uno.csproj
+++ b/SharpClaw.Uno/SharpClaw.Uno.csproj
@@ -54,7 +54,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
     <ProjectReference Include="..\SharpClaw.Utils\SharpClaw.Utils.csproj" />
   </ItemGroup>
 

--- a/SharpClaw.Utils/SharpClaw.Utils.csproj
+++ b/SharpClaw.Utils/SharpClaw.Utils.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpClaw.Contracts" />
+    <ProjectReference Include="..\SharpClaw.Contracts\SharpClaw.Contracts.csproj" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Adds the host-provided in-process module secret reader needed by Curativa to retrieve provider API keys through the Contracts boundary. The main branch uses the embedded SharpClaw.Contracts project updated to assembly identity 0.3.17.0 because direct package consumption would pull unrelated breaking API changes into old main. Focused validation passed: dotnet build SharpClaw.Application.API, dotnet build SharpClaw.Tests, and InProcessModuleSecretReaderTests 8/8.